### PR TITLE
Migrate custom table name

### DIFF
--- a/lib/generators/public_activity/activity/activity_generator.rb
+++ b/lib/generators/public_activity/activity/activity_generator.rb
@@ -7,7 +7,7 @@ module PublicActivity
     class ActivityGenerator < ActiveRecord::Generators::Base
       extend Base
 
-      argument :name, :type => :string, :default => <%= PublicActivity.config.table_name %>
+      argument :name, :type => :string, :default => "#{PublicActivity.config.table_name}"
       # Create model in project's folder
       def generate_files
         copy_file 'activity.rb', "app/models/#{name}.rb"

--- a/lib/generators/public_activity/activity/activity_generator.rb
+++ b/lib/generators/public_activity/activity/activity_generator.rb
@@ -7,10 +7,10 @@ module PublicActivity
     class ActivityGenerator < ActiveRecord::Generators::Base
       extend Base
 
-      argument :name, :type => :string, :default => "#{PublicActivity.config.table_name}"
+      argument :name, :type => :string, :default => "#{PublicActivity.config.table_name.singularize}"
       # Create model in project's folder
       def generate_files
-        copy_file 'activity.rb', "app/models/#{name}.rb"
+        template 'activity.rb', "app/models/#{name}.rb"
       end
     end
   end

--- a/lib/generators/public_activity/activity/activity_generator.rb
+++ b/lib/generators/public_activity/activity/activity_generator.rb
@@ -7,7 +7,7 @@ module PublicActivity
     class ActivityGenerator < ActiveRecord::Generators::Base
       extend Base
 
-      argument :name, :type => :string, :default => 'activity'
+      argument :name, :type => :string, :default => <%= PublicActivity.config.table_name %>
       # Create model in project's folder
       def generate_files
         copy_file 'activity.rb', "app/models/#{name}.rb"

--- a/lib/generators/public_activity/activity/templates/activity.rb
+++ b/lib/generators/public_activity/activity/templates/activity.rb
@@ -1,3 +1,3 @@
 # Activity model for customisation & custom methods
-class Activity < PublicActivity::Activity
+class <%= PublicActivity.config.table_name.camelize %> < PublicActivity::Activity
 end

--- a/lib/generators/public_activity/activity/templates/activity.rb
+++ b/lib/generators/public_activity/activity/templates/activity.rb
@@ -1,3 +1,3 @@
 # Activity model for customisation & custom methods
-class <%= PublicActivity.config.table_name.camelize %> < PublicActivity::Activity
+class <%= PublicActivity.config.table_name.camelize.singularize %> < PublicActivity::Activity
 end

--- a/lib/generators/public_activity/migration/migration_generator.rb
+++ b/lib/generators/public_activity/migration/migration_generator.rb
@@ -7,7 +7,7 @@ module PublicActivity
     class MigrationGenerator < ActiveRecord::Generators::Base
       extend Base
 
-      argument :name, :type => :string, :default => 'create_activities'
+      argument :name, :type => :string, :default => "create_#{PublicActivity.config.table_name}"
       # Create migration in project's folder
       def generate_files
         migration_template 'migration.rb', "db/migrate/#{name}"

--- a/lib/generators/public_activity/migration/templates/migration.rb
+++ b/lib/generators/public_activity/migration/templates/migration.rb
@@ -1,5 +1,5 @@
 # Migration responsible for creating a table with activities
-class CreateActivities < ActiveRecord::Migration
+class Create<%= PublicActivity.config.table_name.camelize %> < ActiveRecord::Migration
   # Create table
   def self.up
     create_table :<%= PublicActivity.config.table_name %> do |t|

--- a/lib/generators/public_activity/migration/templates/migration.rb
+++ b/lib/generators/public_activity/migration/templates/migration.rb
@@ -2,7 +2,7 @@
 class CreateActivities < ActiveRecord::Migration
   # Create table
   def self.up
-    create_table :activities do |t|
+    create_table :<%= PublicActivity.config.table_name %> do |t|
       t.belongs_to :trackable, :polymorphic => true
       t.belongs_to :owner, :polymorphic => true
       t.string  :key
@@ -12,12 +12,12 @@ class CreateActivities < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :activities, [:trackable_id, :trackable_type]
-    add_index :activities, [:owner_id, :owner_type]
-    add_index :activities, [:recipient_id, :recipient_type]
+    add_index :<%= PublicActivity.config.table_name %>, [:trackable_id, :trackable_type]
+    add_index :<%= PublicActivity.config.table_name %>, [:owner_id, :owner_type]
+    add_index :<%= PublicActivity.config.table_name %>, [:recipient_id, :recipient_type]
   end
   # Drop table
   def self.down
-    drop_table :activities
+    drop_table :<%= PublicActivity.config.table_name %>
   end
 end

--- a/lib/generators/public_activity/migration_upgrade/migration_upgrade_generator.rb
+++ b/lib/generators/public_activity/migration_upgrade/migration_upgrade_generator.rb
@@ -7,7 +7,7 @@ module PublicActivity
     class MigrationUpgradeGenerator < ActiveRecord::Generators::Base
       extend Base
 
-      argument :name, :type => :string, :default => 'upgrade_activities'
+      argument :name, :type => :string, :default => "upgrade_#{PublicActivity.config.table_name}"
       # Create migration in project's folder
       def generate_files
         migration_template 'upgrade.rb', "db/migrate/#{name}"

--- a/lib/generators/public_activity/migration_upgrade/templates/upgrade.rb
+++ b/lib/generators/public_activity/migration_upgrade/templates/upgrade.rb
@@ -2,7 +2,7 @@
 class UpgradeActivities < ActiveRecord::Migration
   # Create table
   def self.change
-    change_table :activities do |t|
+    change_table :<%= PublicActivity.config.table_name %> do |t|
       t.belongs_to :recipient, :polymorphic => true
     end
   end

--- a/lib/public_activity/orm/active_record/activist.rb
+++ b/lib/public_activity/orm/active_record/activist.rb
@@ -20,10 +20,10 @@ module PublicActivity
         #   User.first.activities
         #
         def activist
-          has_many :activities_as_owner,
+          has_many "#{PublicActivity.config.table_name}_as_owner".to_sym,
             :class_name => "::PublicActivity::Activity",
             :as => :owner
-          has_many :activities_as_recipient,
+          has_many "#{PublicActivity.config.table_name}_as_recipient".to_sym,
             :class_name => "::PublicActivity::Activity",
             :as => :recipient
         end

--- a/lib/public_activity/orm/active_record/adapter.rb
+++ b/lib/public_activity/orm/active_record/adapter.rb
@@ -8,7 +8,7 @@ module PublicActivity
       class Adapter
         # Creates the activity on `trackable` with `options`
         def self.create_activity(trackable, options)
-          trackable.activities.create options
+          trackable.send(PublicActivity.config.table_name).create options
         end
       end
     end

--- a/lib/public_activity/orm/active_record/trackable.rb
+++ b/lib/public_activity/orm/active_record/trackable.rb
@@ -7,7 +7,7 @@ module PublicActivity
         # Creates an association for activities where self is the *trackable*
         # object.
         def self.extended(base)
-          base.has_many :activities, :class_name => "::PublicActivity::Activity", :as => :trackable
+          base.has_many PublicActivity.config.table_name.to_sym, :class_name => "::PublicActivity::Activity", :as => :trackable
         end
       end
     end

--- a/lib/public_activity/orm/mongo_mapper/activist.rb
+++ b/lib/public_activity/orm/mongo_mapper/activist.rb
@@ -21,10 +21,10 @@ module PublicActivity
         #   User.first.activities
         #
         def activist
-          many :activities_as_owner,
+          many "#{PublicActivity.config.table_name}_as_owner".to_sym,
             :class_name => "::PublicActivity::Activity",
             :as => :owner
-          many :activities_as_recipient,
+          many "#{PublicActivity.config.table_name}_as_recipient".to_sym,
             :class_name => "::PublicActivity::Activity",
             :as => :recipient
         end

--- a/lib/public_activity/orm/mongo_mapper/trackable.rb
+++ b/lib/public_activity/orm/mongo_mapper/trackable.rb
@@ -3,7 +3,7 @@ module PublicActivity
     module MongoMapper
       module Trackable
         def self.extended(base)
-          base.many :activities, :class_name => "::PublicActivity::Activity", order: :created_at.asc, :as => :trackable
+          base.many PublicActivity.config.table_name.to_sym, :class_name => "::PublicActivity::Activity", order: :created_at.asc, :as => :trackable
         end
       end
     end

--- a/lib/public_activity/orm/mongoid/activist.rb
+++ b/lib/public_activity/orm/mongoid/activist.rb
@@ -20,11 +20,11 @@ module PublicActivity
         #   User.first.activities
         #
         def activist
-          has_many :activities_as_owner,
+          has_many "#{PublicActivity.config.table_name}_as_owner".to_sym,
             :class_name => "::PublicActivity::Activity",
             :inverse_of => :owner
 
-          has_many :activities_as_recipient,
+          has_many "#{PublicActivity.config.table_name}_as_recipient".to_sym,
             :class_name => "::PublicActivity::Activity",
             :inverse_of => :recipient
         end

--- a/lib/public_activity/orm/mongoid/trackable.rb
+++ b/lib/public_activity/orm/mongoid/trackable.rb
@@ -3,7 +3,7 @@ module PublicActivity
     module Mongoid
       module Trackable
         def self.extended(base)
-          base.has_many :activities, :class_name => "::PublicActivity::Activity", :as => :trackable
+          base.has_many PublicActivity.config.table_name.to_sym, :class_name => "::PublicActivity::Activity", :as => :trackable
         end
       end
     end

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 echo "Testing active_record 3.X:"
 rm -f Gemfile.lock;
 BUNDLE_GEMFILE=gemfiles/Gemfile.rails-3.X bundle > /dev/null;


### PR DESCRIPTION
This fixes the problem that when installing with an existing table called 'activities', the migrations ignore the custom `table_name` in the initializer. I'm afraid I had a bit of difficulty getting the test to run properly, so have not been able to add test cases yet. I've verified manually that it works, though.