### PR TITLE
Added rake task to truncate PublicActivity::Activity records.

### DIFF
--- a/lib/tasks/public_activity.rake
+++ b/lib/tasks/public_activity.rake
@@ -1,0 +1,11 @@
+namespace :public_activity do
+  desc "Public Activity rake tasks"
+  
+  desc "Deletes PublicActivity::Activity records that are more than x months old.  Usage rake public_activity:truncate[3].  Default 0 months."
+  task :truncate, [:age]=>[:environment] do |t,args|
+    age = args[:age] || 0
+    Setting.load_and_apply
+    x = PublicActivity::Activity.where("created_at < ?", Date.today << age.to_i).delete_all
+    puts "Deleted all PublicActivity::Activity records that are more than %d months old, %d records." % [age,x]
+  end
+end


### PR DESCRIPTION
A convenient rake task to truncate the activity table.  The task allows a parameter to specify the minimum age in months.

Thanks for a GREAT gem - I'm happy to contribute!