### PR TITLE
Get rid of unused code

### DIFF
--- a/lib/public_activity/config.rb
+++ b/lib/public_activity/config.rb
@@ -1,5 +1,3 @@
-require 'singleton'
-
 module PublicActivity
   # Class used to initialize configuration object.
   class Config


### PR DESCRIPTION
`Config` class is not including `Singleton` module. So, It doesn't need to require 'singleton'. 
I think that it needed to be removed in https://github.com/pokonski/public_activity/commit/034d0d31f9921dc9b1308ce9eb64a45728c2cabe .