### PR TITLE
Enable value resolving for Hashes and the parameters option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,21 @@ class Comment < ActiveRecord::Base
 end
 ```
 
+### Resolve parameters from a Symbol or Proc
+
+```ruby
+class Post < ActiveRecord::Base
+  include PublicActivity::Model
+  tracked only: [:update], parameters: :tracked_values
+  
+  def tracked_values
+   {}.tap do |hash|
+     hash[:tags] = tags if tags_changed?
+   end
+  end
+end
+```
+
 #### Setup
 
 **Skip this step if you are using ActiveRecord in Rails 4 or Mongoid**

--- a/lib/public_activity/common.rb
+++ b/lib/public_activity/common.rb
@@ -247,10 +247,11 @@ module PublicActivity
     # be serialized into the Activity#parameters column
     # @api private
     def prepare_parameters(parameters)
-      params = {}
-      params.merge!(self.class.activity_parameters_global)
-        .merge!(parameters || {})
-      params.each { |k, v| params[k] = PublicActivity.resolve_value(self, v) }
+      parameters ||= {}
+
+      [self.class.activity_parameters_global, parameters].reduce({}) do |params, value|
+        params.merge!(PublicActivity.resolve_value(self, value))
+      end
     end
 
     # Prepares relation to be saved

--- a/lib/public_activity/common.rb
+++ b/lib/public_activity/common.rb
@@ -13,11 +13,7 @@ module PublicActivity
     when Proc
       thing.call(PublicActivity.get_controller, context)
     when Hash
-      thing.tap do |hash|
-        hash.each do |key, value|
-          hash[key] = PublicActivity.resolve_value(context, value)
-        end
-      end
+      thing.each { |key, value| thing[key] = PublicActivity.resolve_value(context, value) }
     else
       thing
     end

--- a/lib/public_activity/common.rb
+++ b/lib/public_activity/common.rb
@@ -13,7 +13,11 @@ module PublicActivity
     when Proc
       thing.call(PublicActivity.get_controller, context)
     when Hash
-      thing.dup.each { |key, value| thing[key] = PublicActivity.resolve_value(context, value) }
+      thing.dup.tap do |hash|
+        hash.each do |key, value|
+          hash[key] = PublicActivity.resolve_value(context, value)
+        end
+      end
     else
       thing
     end

--- a/lib/public_activity/common.rb
+++ b/lib/public_activity/common.rb
@@ -248,7 +248,9 @@ module PublicActivity
     end
 
     # Prepares i18n parameters that will
-    # be serialized into the Activity#parameters column
+    # be serialized into the Activity#parameters column.
+    # If a Symbol or a Proc is passed, it will be resolved
+    # expecting to return a Hash.
     # @api private
     def prepare_parameters(parameters)
       parameters ||= {}

--- a/lib/public_activity/common.rb
+++ b/lib/public_activity/common.rb
@@ -13,7 +13,7 @@ module PublicActivity
     when Proc
       thing.call(PublicActivity.get_controller, context)
     when Hash
-      thing.each { |key, value| thing[key] = PublicActivity.resolve_value(context, value) }
+      thing.dup.each { |key, value| thing[key] = PublicActivity.resolve_value(context, value) }
     else
       thing
     end

--- a/lib/public_activity/common.rb
+++ b/lib/public_activity/common.rb
@@ -12,6 +12,12 @@ module PublicActivity
       context.__send__(thing)
     when Proc
       thing.call(PublicActivity.get_controller, context)
+    when Hash
+      thing.tap do |hash|
+        hash.each do |key, value|
+          hash[key] = PublicActivity.resolve_value(context, value)
+        end
+      end
     else
       thing
     end

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -71,6 +71,15 @@ describe PublicActivity::Common do
     subject.activities.last.nonstandard.must_equal "true"
   end
 
+  it 'allows resolving parameters' do
+    subject.save
+    subject.expects(:custom_parameters).returns({ type: 'News' })
+
+    subject.create_activity :update, parameters: :custom_parameters
+
+    subject.activities.last.parameters[:type].must_equal 'News'
+  end
+
   it 'accepts owner as a symbol' do
     klass = article(:owner => :user)
     @article = klass.new(:user => @owner)

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -121,22 +121,43 @@ describe PublicActivity::Common do
   end
 
   # no key implicated or given
-  specify { ->{subject.prepare_settings}.must_raise PublicActivity::NoKeyProvided }
+  specify { -> { subject.prepare_settings }.must_raise PublicActivity::NoKeyProvided }
 
   describe 'resolving values' do
-    it 'allows procs with models and controllers' do
-      context = mock('context')
-      context.expects(:accessor).times(2).returns(5)
-      controller = mock('controller')
-      controller.expects(:current_user).returns(:cu)
-      PublicActivity.set_controller(controller)
-      p = proc {|controller, model|
+    let(:context) { mock('context') }
+    let(:controller) { mock('controller') }
+    let(:closure) do
+      proc do |controller, model|
         assert_equal :cu, controller.current_user
         assert_equal 5, model.accessor
-      }
-      PublicActivity.resolve_value(context, p)
+      end
+    end
+
+    before do
+      PublicActivity.set_controller(controller)
+    end
+
+    it 'allows procs with models and controllers' do
+      context.expects(:accessor).times(2).returns(5)
+      controller.expects(:current_user).returns(:cu)
+
+      PublicActivity.resolve_value(context, closure)
       PublicActivity.resolve_value(context, :accessor)
     end
-  end
 
+    describe 'passing hash values' do
+      it 'allows procs with controllers' do
+        context.expects(:accessor).returns(5)
+        controller.expects(:current_user).returns(:cu)
+
+        PublicActivity.resolve_value(context, { value: closure }).must_equal({ value: true })
+      end
+
+      it 'allows symbols' do
+        context.expects(:accessor).returns(5)
+
+        PublicActivity.resolve_value(context, { value: :accessor }).must_equal({ value: 5 })
+      end
+    end
+  end
 end


### PR DESCRIPTION
I've started using this gem for tracking user events and ran into a case where I needed another serialized Hash(similiar to parameters), but one that would be encrypted. Therefore I noticed that PublicActivity.resolve_value is not able to resolve values inside hashes, when passing a custom parameter. So I had to monkey patch it. I've figured this could be useful for more people aswell. Please add some feedback if there's something you do not like about this.

Update:

I've also ran into issues when trying to pass a symbol into the parameters option when trying to automatically include changed attributes on model's update. This worked for me, I hope it looks good enough for you.